### PR TITLE
Refilter the app list after a refresh.

### DIFF
--- a/app/src/main/java/subreddit/android/appstore/screens/list/AppListFragment.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/list/AppListFragment.java
@@ -138,7 +138,7 @@ public class AppListFragment extends BasePresenterFragment<AppListContract.Prese
     @Override
     public void showAppList(List<AppInfo> appInfos) {
         appListAdapter.setData(appInfos);
-        appListAdapter.notifyDataSetChanged();
+        appListAdapter.getFilter().filter(appListAdapter.getFilter().getFilterString());
         swipeRefresh.setRefreshing(false);
         setHasOptionsMenu(true);
     }


### PR DESCRIPTION
If you filter (by watch & paid for example) you will see four apps, if you swipe down and refresh it will refresh but populate the recyclerview with every app, ignoring the current filter. This seems to fix it.