### PR TITLE
Prepend global tag to Timber debug tree

### DIFF
--- a/app/src/main/java/subreddit/android/appstore/AppStoreApp.java
+++ b/app/src/main/java/subreddit/android/appstore/AppStoreApp.java
@@ -24,7 +24,15 @@ public class AppStoreApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        if (BuildConfig.DEBUG) Timber.plant(new Timber.DebugTree());
+        if (BuildConfig.DEBUG) {
+            Timber.plant(new Timber.DebugTree() {
+                @Override
+                protected void log(final int priority, final String tag, final String message,
+                                   final Throwable t) {
+                    super.log(priority, LOGPREFIX + tag, message, t);
+                }
+            });
+        }
         refWatcher = LeakCanary.install(this);
         Injector.INSTANCE.init(this);
         theme = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(this).getString("theme", "0"));

--- a/app/src/main/java/subreddit/android/appstore/backend/data/AppInfo.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/data/AppInfo.java
@@ -10,13 +10,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
-import subreddit.android.appstore.AppStoreApp;
 import timber.log.Timber;
 
 
 public class AppInfo implements Comparable<AppInfo> {
-    final static String TAG = AppStoreApp.LOGPREFIX + "AppInfo";
-
     final Collection<AppTags> appTagsCollection = new LinkedHashSet<>();
     final Collection<Contact> contacts = new ArrayList<>();
     final Collection<Download> downloads = new ArrayList<>();
@@ -92,7 +89,7 @@ public class AppInfo implements Comparable<AppInfo> {
         try {
             return gson.fromJson(jsonString, AppInfo.class);
         } catch (JsonSyntaxException e) {
-            Timber.tag(TAG).e(e, "Failed to create AppInfo from: %s", jsonString);
+            Timber.e(e, "Failed to create AppInfo from: %s", jsonString);
             return null;
         }
     }

--- a/app/src/main/java/subreddit/android/appstore/backend/scrapers/LiveMediaScraper.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/scrapers/LiveMediaScraper.java
@@ -6,7 +6,6 @@ import android.support.v4.util.LruCache;
 
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.UnsupportedScrapeTargetException;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.data.Download;
@@ -15,7 +14,6 @@ import subreddit.android.appstore.backend.scrapers.gplay.GPlayScraper;
 import timber.log.Timber;
 
 public class LiveMediaScraper implements MediaScraper {
-    static final String TAG = AppStoreApp.LOGPREFIX + "LiveScraper";
     final LruCache<AppInfo, Observable<ScrapeResult>> scrapeCache = new LruCache<>(1);
     final ScrapeDiskCache scrapeDiskCache;
     final GPlayScraper gPlayScraper = new GPlayScraper();
@@ -41,19 +39,19 @@ public class LiveMediaScraper implements MediaScraper {
                         )
                         .cache();
                 scrapeCache.put(appToScrape, scrapeResultObserver);
-            } else Timber.tag(TAG).d("Using cached result for %s", appToScrape);
+            } else Timber.d("Using cached result for %s", appToScrape);
             return scrapeResultObserver;
         }
     }
 
     private Observable<ScrapeResult> doScrape(@NonNull AppInfo appToScrape) {
-        Timber.tag(TAG).d("Scraping %s", appToScrape.toString());
+        Timber.d("Scraping %s", appToScrape.toString());
         for (Download download : appToScrape.getDownloads()) {
             switch (download.getType()) {
                 case GPLAY:
                     return gPlayScraper.get(appToScrape);
                 default:
-                    Timber.tag(TAG).d("No scraper available for type %s", download.getType());
+                    Timber.d("No scraper available for type %s", download.getType());
             }
         }
         return Observable.error(new UnsupportedScrapeTargetException(appToScrape));

--- a/app/src/main/java/subreddit/android/appstore/backend/scrapers/caching/ScrapeDiskCache.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/scrapers/caching/ScrapeDiskCache.java
@@ -8,19 +8,17 @@ import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.functions.Function;
 import io.realm.Realm;
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.scrapers.ScrapeResult;
 import timber.log.Timber;
 
 public class ScrapeDiskCache {
-    static final String TAG = AppStoreApp.LOGPREFIX + "ScrapeDiskCache";
 
     public ScrapeDiskCache(Context context) {
     }
 
     public void put(AppInfo appInfo, ScrapeResult scrapeResult) {
-        Timber.tag(TAG).d("Storing <%s,%s>", appInfo, scrapeResult);
+        Timber.d("Storing <%s,%s>", appInfo, scrapeResult);
         Realm realm = Realm.getDefaultInstance();
         realm.beginTransaction();
         realm.copyToRealmOrUpdate(new CachedScrape(appInfo, scrapeResult));
@@ -42,7 +40,7 @@ public class ScrapeDiskCache {
                     @Override
                     public ScrapeResult apply(CachedScrape cachedScrape) throws Exception {
                         ScrapeResult scrapeResult = cachedScrape.toBaseScrapeResult();
-                        Timber.tag(TAG).d("Returning get(%s): %s", appInfo, scrapeResult);
+                        Timber.d("Returning get(%s): %s", appInfo, scrapeResult);
                         return scrapeResult;
                     }
                 });

--- a/app/src/main/java/subreddit/android/appstore/backend/scrapers/gplay/GPlayScraper.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/scrapers/gplay/GPlayScraper.java
@@ -14,7 +14,6 @@ import io.reactivex.functions.Function;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.DeadLinkException;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.data.Download;
@@ -24,7 +23,6 @@ import subreddit.android.appstore.backend.scrapers.ScrapeResult;
 import timber.log.Timber;
 
 public class GPlayScraper implements MediaScraper {
-    static final String TAG = AppStoreApp.LOGPREFIX + "GPlayScraper";
     final OkHttpClient client = new OkHttpClient();
 
     @NonNull
@@ -36,7 +34,7 @@ public class GPlayScraper implements MediaScraper {
                     public void subscribe(ObservableEmitter<String> e) throws Exception {
                         for (Download d : appToScrape.getDownloads()) {
                             if (d.getType() == Download.Type.GPLAY) {
-                                Timber.tag(TAG).d("Scraping %s", d.getTarget());
+                                Timber.d("Scraping %s", d.getTarget());
                                 e.onNext(d.getTarget());
                             }
                         }
@@ -59,7 +57,7 @@ public class GPlayScraper implements MediaScraper {
                         int iconStart = body.indexOf("<img class=\"cover-image\"");
                         int iconEnd = body.indexOf("\" alt=\"Cover art\"", iconStart);
                         String iconUrl = body.substring(body.indexOf("lh", iconStart), iconEnd);
-                        Timber.tag(TAG).v("%s | icon url: %s", appToScrape, iconUrl);
+                        Timber.v("%s | icon url: %s", appToScrape, iconUrl);
 
                         // Strip size parameter we generate these
                         iconUrl = iconUrl.replaceAll("=(w|h)\\d+", "");
@@ -73,7 +71,7 @@ public class GPlayScraper implements MediaScraper {
                             int subEnd = screenUrl.indexOf("\"", subStart);
                             screenUrl = screenUrl.substring(subStart, subEnd);
                             body = body.substring(end, body.length());
-                            Timber.tag(TAG).v("%s | screenshot url: %s", appToScrape, screenUrl);
+                            Timber.v("%s | screenshot url: %s", appToScrape, screenUrl);
 
                             // Strip size parameter we generate these
                             screenUrl = screenUrl.replaceAll("=(w|h)\\d+", "");

--- a/app/src/main/java/subreddit/android/appstore/backend/wiki/LiveWikiRepository.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/wiki/LiveWikiRepository.java
@@ -14,7 +14,6 @@ import io.reactivex.subjects.ReplaySubject;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.wiki.caching.WikiDiskCache;
 import subreddit.android.appstore.backend.wiki.parser.BodyParser;
@@ -22,7 +21,6 @@ import timber.log.Timber;
 
 
 public class LiveWikiRepository implements WikiRepository {
-    static final String TAG = AppStoreApp.LOGPREFIX + "LiveWikiRepository";
     static final String TARGET_URL = "https://www.reddit.com/r/Android/wiki/apps";
     final OkHttpClient client = new OkHttpClient();
     final WikiDiskCache wikiDiskCache;
@@ -84,19 +82,19 @@ public class LiveWikiRepository implements WikiRepository {
                 .map(new Function<Response, Collection<AppInfo>>() {
                     @Override
                     public Collection<AppInfo> apply(Response response) throws Exception {
-                        Timber.tag(TAG).d(response.toString());
+                        Timber.d(response.toString());
                         long timeStart = System.currentTimeMillis();
                         Collection<AppInfo> infos = new ArrayList<>();
                         infos.addAll(new BodyParser().parseBody(response.body()));
                         long timeStop = System.currentTimeMillis();
-                        Timber.tag(TAG).d("Parsed %d items in %dms", infos.size(), (timeStop - timeStart));
+                        Timber.d("Parsed %d items in %dms", infos.size(), (timeStop - timeStart));
                         return infos;
                     }
                 })
                 .onErrorReturn(new Function<Throwable, Collection<AppInfo>>() {
                     @Override
                     public Collection<AppInfo> apply(Throwable throwable) throws Exception {
-                        Timber.tag(TAG).e(throwable, "Error while fetching wiki repository");
+                        Timber.e(throwable, "Error while fetching wiki repository");
                         return new ArrayList<>();
                     }
                 });

--- a/app/src/main/java/subreddit/android/appstore/backend/wiki/caching/WikiDiskCache.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/wiki/caching/WikiDiskCache.java
@@ -16,12 +16,10 @@ import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import io.realm.Realm;
 import io.realm.RealmResults;
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 import timber.log.Timber;
 
 public class WikiDiskCache {
-    static final String TAG = AppStoreApp.LOGPREFIX + "WikiDiskCache";
     final Gson gson;
 
     public WikiDiskCache(Context context) {
@@ -29,7 +27,7 @@ public class WikiDiskCache {
     }
 
     public void putAll(Collection<AppInfo> appInfos) {
-        Timber.tag(TAG).d("Storing %d appinfos", appInfos.size());
+        Timber.d("Storing %d appinfos", appInfos.size());
         Realm realm = Realm.getDefaultInstance();
         realm.beginTransaction();
         realm.delete(CachedAppInfo.class);
@@ -37,13 +35,13 @@ public class WikiDiskCache {
             long start = System.currentTimeMillis();
             realm.copyToRealm(new CachedAppInfo(gson, appInfo));
             long stop = System.currentTimeMillis();
-            Timber.tag(TAG).v("Stored: %s (%d ms)", appInfo, (stop - start));
+            Timber.v("Stored: %s (%d ms)", appInfo, (stop - start));
         }
         realm.commitTransaction();
     }
 
     public Observable<Collection<AppInfo>> getAll() {
-        Timber.tag(TAG).d("Getting all cached AppInfos");
+        Timber.d("Getting all cached AppInfos");
         // TODO invalidate old data at some point?
         return Observable.create(
                 new ObservableOnSubscribe<RealmResults<CachedAppInfo>>() {
@@ -52,7 +50,7 @@ public class WikiDiskCache {
                         Realm realm = Realm.getDefaultInstance();
                         RealmResults<CachedAppInfo> realmResults = realm.where(CachedAppInfo.class).findAll();
                         if (!realmResults.isEmpty()) e.onNext(realmResults);
-                        else Timber.tag(TAG).d("No AppInfos cached");
+                        else Timber.d("No AppInfos cached");
                         e.onComplete();
                     }
                 })
@@ -61,7 +59,7 @@ public class WikiDiskCache {
                     @Override
                     public Collection<AppInfo> apply(RealmResults<CachedAppInfo> cachedAppInfos) throws Exception {
                         Collection<AppInfo> appInfos = new ArrayList<>();
-                        Timber.tag(TAG).d("Returned %d AppInfos from cache", cachedAppInfos.size());
+                        Timber.d("Returned %d AppInfos from cache", cachedAppInfos.size());
                         for (CachedAppInfo cachedAppInfo : cachedAppInfos) appInfos.add(cachedAppInfo.toAppInfo(gson));
                         return appInfos;
                     }

--- a/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/BodyParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/BodyParser.java
@@ -11,11 +11,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import okhttp3.ResponseBody;
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 
 public class BodyParser {
-    private static final String TAG = AppStoreApp.LOGPREFIX + "BodyParser";
     private static final Pattern PRIMARY_CATEGORY_PATTERN = Pattern.compile("^(?:#(?!#+)\\s?)(.+?)$");
     private final List<AppParser> appParsers = new ArrayList<>();
 

--- a/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/CategoryParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/CategoryParser.java
@@ -4,12 +4,10 @@ import android.text.Html;
 
 import java.util.Map;
 
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 
 
 public class CategoryParser implements AppParser {
-    static final String TAG = AppStoreApp.LOGPREFIX + "CategoryParser";
 
     @Override
     public void parse(AppInfo appInfo, Map<Column, String> rawColumns) {

--- a/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/ContactColumnParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/ContactColumnParser.java
@@ -4,14 +4,12 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.data.Contact;
 import timber.log.Timber;
 
 
 public class ContactColumnParser implements AppParser {
-    static final String TAG = AppStoreApp.LOGPREFIX + "ContactColumnParser";
     final static Pattern EMAIL_PATTERN = Pattern.compile("(\\b[\\w._%+-]+@[\\w.-]+\\.[\\w]{2,}\\b)");
     final static Pattern REDDIT_PATTERN = Pattern.compile("(/u/[\\-_\\w]+\\b)");
     final static Pattern WEBSITE_MATCHER = Pattern.compile("(?:\\[.+\\])\\((http.?://.+)\\)");
@@ -35,7 +33,7 @@ public class ContactColumnParser implements AppParser {
             appInfo.getContacts().add(contact);
         }
         if (appInfo.getContacts().isEmpty()) {
-            Timber.tag(TAG).w("No contacts parsed from %s", raw);
+            Timber.w("No contacts parsed from %s", raw);
             appInfo.getContacts().add(new Contact(Contact.Type.UNKNOWN, raw));
         }
     }

--- a/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/DescriptionColumnParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/DescriptionColumnParser.java
@@ -4,11 +4,9 @@ import android.text.Html;
 
 import java.util.Map;
 
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 
 public class DescriptionColumnParser implements AppParser {
-    static final String TAG = AppStoreApp.LOGPREFIX + "DescriptionColumnParser";
 
     @Override
     public void parse(AppInfo appInfo, Map<Column, String> rawColumns) {

--- a/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/DeviceColumnParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/DeviceColumnParser.java
@@ -2,13 +2,11 @@ package subreddit.android.appstore.backend.wiki.parser;
 
 import java.util.Map;
 
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.data.AppTags;
 
 
 public class DeviceColumnParser implements AppParser {
-    static final String TAG = AppStoreApp.LOGPREFIX + "DeviceColumnParser";
 
     @Override
     public void parse(AppInfo appInfo, Map<Column, String> rawColumns) {

--- a/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/NameColumnParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/NameColumnParser.java
@@ -6,14 +6,12 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.data.Download;
 import timber.log.Timber;
 
 
 public class NameColumnParser implements AppParser {
-    static final String TAG = AppStoreApp.LOGPREFIX + "NameColumnparser";
     static final Pattern NAME_PATTERN = Pattern.compile("^(?:\\[(.+)\\]\\((.+)\\))$");
 
     @Override
@@ -34,13 +32,13 @@ public class NameColumnParser implements AppParser {
                 downloadType = Download.Type.GPLAY;
             } else {
                 downloadType = Download.Type.UNKNOWN;
-                Timber.tag(TAG).w("Unknown download url: %s", downloadUrl);
+                Timber.w("Unknown download url: %s", downloadUrl);
             }
         } else {
             appName = rawNameString;
             downloadUrl = rawNameString;
             downloadType = Download.Type.UNKNOWN;
-            Timber.tag(TAG).w("parseNameField(%s) failed", rawNameString);
+            Timber.w("parseNameField(%s) failed", rawNameString);
         }
         appInfo.setAppName(Html.fromHtml(appName).toString());
         appInfo.addDownload(new Download(downloadType, downloadUrl));

--- a/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/PriceColumnParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/wiki/parser/PriceColumnParser.java
@@ -2,13 +2,11 @@ package subreddit.android.appstore.backend.wiki.parser;
 
 import java.util.Map;
 
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.data.AppTags;
 
 
 public class PriceColumnParser implements AppParser {
-    static final String TAG = AppStoreApp.LOGPREFIX + "PriceColumnParser";
 
     @Override
     public void parse(AppInfo appInfo, Map<Column, String> rawColumns) {

--- a/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsPresenter.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsPresenter.java
@@ -13,7 +13,6 @@ import subreddit.android.appstore.backend.scrapers.ScrapeResult;
 
 
 public class AppDetailsPresenter implements AppDetailsContract.Presenter {
-    static final String TAG = AppStoreApp.LOGPREFIX + "AppDetailsPresenter";
     AppDetailsContract.View view;
     private final MediaScraper mediaScraper;
     private AppInfo appInfoItem;

--- a/app/src/main/java/subreddit/android/appstore/screens/list/AppListPresenter.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/list/AppListPresenter.java
@@ -13,7 +13,6 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.wiki.WikiRepository;
 import subreddit.android.appstore.screens.navigation.CategoryFilter;
@@ -21,7 +20,6 @@ import timber.log.Timber;
 
 
 public class AppListPresenter implements AppListContract.Presenter {
-    static final String TAG = AppStoreApp.LOGPREFIX + "AppListPresenter";
     final WikiRepository repository;
     final CategoryFilter categoryFilter;
     private Disposable listUpdater;
@@ -64,7 +62,7 @@ public class AppListPresenter implements AppListContract.Presenter {
                 .subscribe(new Consumer<List<AppInfo>>() {
                     @Override
                     public void accept(List<AppInfo> appInfos) throws Exception {
-                        Timber.tag(TAG).d("showAppList(%s items)", appInfos.size());
+                        Timber.d("showAppList(%s items)", appInfos.size());
                         AppListPresenter.this.view.showAppList(appInfos);
                     }
                 });
@@ -80,7 +78,7 @@ public class AppListPresenter implements AppListContract.Presenter {
                 .subscribe(new Consumer<TagMap>() {
                     @Override
                     public void accept(TagMap tagMap) throws Exception {
-                        Timber.tag(TAG).d("updateTagCount(%s)", tagMap);
+                        Timber.d("updateTagCount(%s)", tagMap);
                         AppListPresenter.this.view.updateTagCount(tagMap);
                     }
                 });

--- a/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationPresenter.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationPresenter.java
@@ -9,14 +9,12 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
-import subreddit.android.appstore.AppStoreApp;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.wiki.WikiRepository;
 import timber.log.Timber;
 
 
 public class NavigationPresenter implements NavigationContract.Presenter {
-    static final String TAG = AppStoreApp.LOGPREFIX + "NavigationPresenter";
     final WikiRepository repository;
 
     NavigationContract.View view;
@@ -49,7 +47,7 @@ public class NavigationPresenter implements NavigationContract.Presenter {
                 .subscribe(new Consumer<NavigationData>() {
                     @Override
                     public void accept(NavigationData navigationData) throws Exception {
-                        Timber.tag(TAG).d("showNavigationItems(%s)", navigationData);
+                        Timber.d("showNavigationItems(%s)", navigationData);
                         NavigationPresenter.this.view.showNavigationItems(navigationData, currentCategoryFilter);
                     }
                 });


### PR DESCRIPTION
This saves having to manually set the tag for each Timber log call. [Here's a link](https://www.reddit.com/r/androiddev/comments/4zfkup/an_easy_way_to_add_a_universal_tag_to_all_timber/) to a Reddit post I made a few weeks ago about how I solved this exact same problem before.