### PR TITLE
Issue #74: Fix crash when sending email with no email client/account

### DIFF
--- a/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsFragment.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsFragment.java
@@ -46,6 +46,7 @@ import subreddit.android.appstore.util.mvp.BasePresenterFragment;
 import subreddit.android.appstore.util.mvp.PresenterFactory;
 import subreddit.android.appstore.util.ui.glide.IconRequest;
 import subreddit.android.appstore.util.ui.glide.PlaceHolderRequestListener;
+import timber.log.Timber;
 
 
 public class AppDetailsFragment extends BasePresenterFragment<AppDetailsContract.Presenter, AppDetailsContract.View>
@@ -188,7 +189,14 @@ public class AppDetailsFragment extends BasePresenterFragment<AppDetailsContract
     void openContact(Contact c) {
         switch (c.getType()) {
             case EMAIL:
-                startActivity(new Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", c.getTarget(), null)));
+                try {
+                    startActivity(new Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", c.getTarget(), null)));
+                } catch (Exception e) {
+                    Timber.e(e, "Problem launching intent for Email contact");
+                    Toast.makeText(getContext(), getContext().getResources().getString(R.string.no_email_client), Toast.LENGTH_LONG).show();
+                    //note: translations pulled straight from google translate, someone might want to double check
+                }
+
                 break;
             case WEBSITE:
                 // TODO do reddit apps recognize a specific message intent?

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -38,4 +38,5 @@
     <string name="version">Version</string>
     <string name="website">Internetseite</string>
     <string name="app_category_new">Neu</string>
+    <string name="no_email_client">Kein E-Mail-Client verfügbar</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -42,4 +42,5 @@
         <item quantity="other">%s items</item>
     </plurals>
     <string name="app_category_new">Nuovo</string>
+    <string name="no_email_client">Nessun client di posta elettronica disponibile</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -38,4 +38,5 @@
     <string name="version">Версия</string>
     <string name="website">Веб-сайт</string>
     <string name="app_category_new">новый</string>
+    <string name="no_email_client">Отсутствует клиент электронной почты</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="update_confirm">Update</string>
     <string name="flag">Flag app</string>
     <string name="no_message">Please enter a message</string>
+    <string name="no_email_client">No email client available</string>
     <string name="flag_text">Please describe why you are flagging this app. You will be redirected to reddit to send a PM to the r/Android mod team</string>
     <plurals name="x_items">
         <item quantity="one">%s item</item>


### PR DESCRIPTION
- Catches error when there is no email client or when no email account is logged in, displays toast instead
- Includes Google-translated translations for the toast, someone might want to take a look at some point
![screenshot_20170621-155635](https://user-images.githubusercontent.com/23356519/27410493-cd9037c0-569c-11e7-9a13-4bdc234f186e.png)
