### PR TITLE
Issue #44: Show changelog of latest release

### DIFF
--- a/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationContract.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationContract.java
@@ -19,11 +19,15 @@ public interface NavigationContract {
         void enableUpdateAvailableText(@Nullable SelfUpdater.Release release);
 
         void showDownload(String url);
+
+        void showChangelog(SelfUpdater.Release release);
     }
 
     interface Presenter extends BasePresenter<View> {
         void notifySelectedFilter(CategoryFilter categoryFilter);
 
         void downloadUpdate(SelfUpdater.Release release);
+
+        void buildChangelog(SelfUpdater.Release release);
     }
 }

--- a/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationFragment.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationFragment.java
@@ -9,6 +9,8 @@ import android.support.customtabs.CustomTabsIntent;
 import android.support.design.widget.NavigationView;
 import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AlertDialog;
+import android.text.format.DateFormat;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -16,6 +18,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -95,14 +98,14 @@ public class NavigationFragment extends BasePresenterFragment<NavigationContract
         if (release == null) return;
         Snackbar
                 .make(navigationView, R.string.update, Snackbar.LENGTH_LONG)
-                .setAction(R.string.update_confirm, view -> getPresenter().downloadUpdate(release)).show();
+                .setAction(R.string.view_update, view -> getPresenter().buildChangelog(release)).show();
     }
 
     @Override
     public void enableUpdateAvailableText(SelfUpdater.Release release) {
         if (release != null) {
             updateBanner.setVisibility(View.VISIBLE);
-            updateBanner.setOnClickListener(v -> getPresenter().downloadUpdate(release));
+            updateBanner.setOnClickListener(v -> getPresenter().buildChangelog(release));
         }
     }
 
@@ -113,6 +116,22 @@ public class NavigationFragment extends BasePresenterFragment<NavigationContract
         builder.setSecondaryToolbarColor(ContextCompat.getColor(getActivity(), R.color.colorPrimary));
         CustomTabsIntent customTabsIntent = builder.build();
         customTabsIntent.launchUrl(getActivity(), Uri.parse(url));
+    }
+
+    public void showChangelog(SelfUpdater.Release release) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        Date date = release.publishDate;
+        String desc = release.releaseDescription;
+        String name = release.releaseName;
+        String tag = release.tagName;
+
+        builder.setMessage(DateFormat.format("MMM", date) + " "
+                    + DateFormat.format("dd", date) + "\n" + desc)
+                .setTitle(tag + ": " + name);
+        builder.setPositiveButton(R.string.update_confirm, (dialog, id) -> getPresenter().downloadUpdate(release));
+        builder.setNegativeButton(R.string.cancel, (dialog, id) -> dialog.dismiss());
+        AlertDialog dialog = builder.create();
+        dialog.show();
     }
 
     @Override

--- a/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationPresenter.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationPresenter.java
@@ -110,4 +110,9 @@ public class NavigationPresenter implements NavigationContract.Presenter {
         // TODO we could directory use Androids DownloadManager.class
         view.showDownload(release.assets.get(0).downloadUrl);
     }
+
+    @Override
+    public void buildChangelog(SelfUpdater.Release release) {
+        view.showChangelog(release);
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="later">Later</string>
     <string name="app_category_everything">All</string>
     <string name="app_category_new">New</string>
+    <string name="view_update">View</string>
     <string name="error">Error fetching repository</string>
     <string name="data_options">Data options</string>
     <string name="screenshots">Screenshots</string>
@@ -35,6 +36,7 @@
     <string name="data_option_loadmedia_summary">Load app icons and screenshots</string>
     <string name="update">Update available</string>
     <string name="update_confirm">Update</string>
+    <string name="cancel">Cancel</string>
     <string name="flag">Flag app</string>
     <string name="no_message">Please enter a message</string>
     <string name="no_email_client">No email client available</string>

--- a/app/src/mock/java/subreddit/android/appstore/backend/github/FakeSelfUpdater.java
+++ b/app/src/mock/java/subreddit/android/appstore/backend/github/FakeSelfUpdater.java
@@ -2,6 +2,8 @@ package subreddit.android.appstore.backend.github;
 
 
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.List;
 
 import io.reactivex.Observable;
@@ -10,8 +12,15 @@ public class FakeSelfUpdater implements SelfUpdater {
     @Override
     public Observable<Release> getLatestRelease() {
         Release release = new Release();
-        release.releaseName = "v100.100.100";
+        release.releaseName = "A Fabulous Release";
         release.tagName = "v100.100.100";
+        release.publishDate = new GregorianCalendar(2017, Calendar.MARCH, 11).getTime();
+        release.releaseDescription = "This update fixes x, x, x";
+        release.assets = new ArrayList<>();
+        Release.Assets a = new Release.Assets();
+        a.downloadUrl = "https://github.com/d4rken/reddit-android-appstore/releases/download/v0.6.0/rAndroid_AppStore-v0.6.0.6000.-RELEASE-ee4ee75.apk";
+        release.assets.add(a);
+
         return Observable.just(release);
     }
 


### PR DESCRIPTION
- Tapping the snackbar link or sidebar "Update Available" link will now open a changelog dialog
- Dialog displays release tag, release name, date of release and the release description:
![screenshot_20170622-221353](https://user-images.githubusercontent.com/23356519/27467642-f4f1c822-5798-11e7-8bde-85396e5d8f7e.png)
- Updated FakeSelfUpdater