### PR TITLE
Fix #102: Close DrawerLayout on back key

### DIFF
--- a/app/src/main/java/subreddit/android/appstore/screens/MainActivity.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/MainActivity.java
@@ -5,6 +5,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.widget.Toolbar;
+import android.view.KeyEvent;
 import android.view.View;
 
 import butterknife.BindView;
@@ -36,6 +37,14 @@ public class MainActivity extends BaseActivity implements View.OnClickListener, 
         getSupportFragmentManager().beginTransaction().replace(R.id.navigationFrame, navigationFragment).commit();
 
         if (savedInstanceState == null) onCategorySelected(new CategoryFilter());
+
+        addOnBackKeyPressedListener(() -> {
+            if (drawerLayout.isDrawerVisible(GravityCompat.START)) {
+                drawerLayout.closeDrawer(GravityCompat.START);
+                return true;
+            }
+            return false;
+        });
     }
 
     @Override
@@ -55,4 +64,5 @@ public class MainActivity extends BaseActivity implements View.OnClickListener, 
         }
         toolbar.setTitle(filter.getName(this));
     }
+
 }

--- a/app/src/main/java/subreddit/android/appstore/screens/list/AppListFragment.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/list/AppListFragment.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.view.MenuItemCompat;
@@ -42,6 +43,7 @@ import subreddit.android.appstore.screens.details.AppDetailsActivity;
 import subreddit.android.appstore.screens.navigation.CategoryFilter;
 import subreddit.android.appstore.util.mvp.BasePresenterFragment;
 import subreddit.android.appstore.util.mvp.PresenterFactory;
+import subreddit.android.appstore.util.ui.BaseActivity;
 import subreddit.android.appstore.util.ui.BaseViewHolder;
 import subreddit.android.appstore.util.ui.DividerItemDecoration;
 
@@ -63,6 +65,8 @@ public class AppListFragment extends BasePresenterFragment<AppListContract.Prese
     AppListAdapter appListAdapter;
     FilterListAdapter filterListAdapter;
     Collection<AppTags> appTags;
+
+    private BaseActivity.OnBackKeyPressedListener closeDrawerOnBackKeyListener;
 
     public static Fragment newInstance(@NonNull CategoryFilter categoryFilter) {
         AppListFragment fragment = new AppListFragment();
@@ -114,6 +118,19 @@ public class AppListFragment extends BasePresenterFragment<AppListContract.Prese
         filterList.addItemDecoration(new DividerItemDecoration(getContext(), DividerItemDecoration.VERTICAL_LIST));
         filterListAdapter = new FilterListAdapter(this);
         filterList.setAdapter(filterListAdapter);
+
+        final FragmentActivity activity = getActivity();
+        if (activity instanceof BaseActivity) {
+            closeDrawerOnBackKeyListener = () -> {
+                if (drawerLayout != null && drawerLayout.isDrawerVisible(GravityCompat.END)) {
+                    drawerLayout.closeDrawer(GravityCompat.END);
+                    return true;
+                }
+                return false;
+            };
+            ((BaseActivity) activity).addOnBackKeyPressedListener(closeDrawerOnBackKeyListener);
+        }
+
         super.onViewCreated(view, savedInstanceState);
     }
 
@@ -137,6 +154,12 @@ public class AppListFragment extends BasePresenterFragment<AppListContract.Prese
     @Override
     public void onDestroyView() {
         if (unbinder != null) unbinder.unbind();
+
+        final FragmentActivity activity = getActivity();
+        if (closeDrawerOnBackKeyListener != null && activity instanceof BaseActivity) {
+            ((BaseActivity) activity).removeOnBackKeyPressedListener(closeDrawerOnBackKeyListener);
+        }
+
         super.onDestroyView();
     }
 

--- a/app/src/main/java/subreddit/android/appstore/util/ui/BaseActivity.java
+++ b/app/src/main/java/subreddit/android/appstore/util/ui/BaseActivity.java
@@ -4,10 +4,23 @@ import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.support.v7.app.AppCompatActivity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import subreddit.android.appstore.AppStoreApp;
+import subreddit.android.appstore.screens.MainActivity;
+import timber.log.Timber;
 
 
 public class BaseActivity extends AppCompatActivity {
+
+
+    /**
+     * Use {@code 2} as initial capacity for the navigation and tag drawers in {@link MainActivity},
+     * as it's the most used case
+     */
+    private final List<OnBackKeyPressedListener> onBackKeyPressedListeners = new ArrayList<>(2);
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -25,5 +38,46 @@ public class BaseActivity extends AppCompatActivity {
     protected void onDestroy() {
         super.onDestroy();
         AppStoreApp.getRefWatcher().watch(this);
+    }
+
+
+    @Override
+    public void onBackPressed() {
+        boolean handled = false;
+        for (OnBackKeyPressedListener listener : onBackKeyPressedListeners) {
+            if (listener.onBackKeyPressed()) {
+                handled = true;
+                break;
+            }
+        }
+
+        if (!handled) {
+            super.onBackPressed();
+        }
+    }
+
+    public void addOnBackKeyPressedListener(OnBackKeyPressedListener listener) {
+        if (!onBackKeyPressedListeners.contains(listener)) {
+            onBackKeyPressedListeners.add(listener);
+        } else {
+            Timber.w(new IllegalArgumentException("A back key listener was added twice"),
+                    "A back key listener was added twice: %s", listener);
+        }
+    }
+
+    public void removeOnBackKeyPressedListener(OnBackKeyPressedListener listener) {
+        if (onBackKeyPressedListeners.contains(listener)) {
+            onBackKeyPressedListeners.remove(listener);
+        } else {
+            Timber.w(new IllegalArgumentException("A back key listener was removed but never added"),
+                    "A back key listener was removed but never added: %s", listener);
+        }
+    }
+
+    public interface OnBackKeyPressedListener {
+        /**
+         * @return true if the event was handled, false otherwise
+         */
+        boolean onBackKeyPressed();
     }
 }


### PR DESCRIPTION
Added methods to BaseActivity to listen for back key presses.
Registered a listener in MainActivity and AppListFragment to close
navigation and filter drawers when they were visible.

Not sure if you want the logic for closing the `DrawerLayouts` straight into the activity and fragment.
It's possible that the logic should reside inside the `AppListFragment`'s presenter.
However I found it to be kind of useless ping-pong back and forth between the fragment and presenter. 

Instanceof in the `AppListFragment` is somewhat ugly, but it works.