### PR TITLE
Fixes #124: Display toast when no client is available to handle download

### DIFF
--- a/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/NameColumnParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/NameColumnParser.java
@@ -28,7 +28,7 @@ public class NameColumnParser extends BaseParser {
         if (matcher.matches()) {
             appName = matcher.group(1);
 
-            downloadUrl = matcher.group(2);
+            downloadUrl = matcher.group(2).replaceAll(" ","");
             // TODO more parsing of different types
             if (downloadUrl.contains("://play.google.com/store") || downloadUrl.contains("://market.android.com")) {
                 downloadType = Download.Type.GPLAY;

--- a/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsFragment.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsFragment.java
@@ -183,7 +183,12 @@ public class AppDetailsFragment extends BasePresenterFragment<AppDetailsContract
     }
 
     void openDownload(Download d) {
-        startActivity(new Intent(Intent.ACTION_VIEW, d.getDownloadUri()));
+        try {
+            startActivity(new Intent(Intent.ACTION_VIEW, d.getDownloadUri()));
+        } catch (Exception e) {
+            Timber.e(e, "Problem launching intent for a Download link");
+            displayToast(R.string.no_download_client);
+        }
     }
 
     void openContact(Contact c) {
@@ -193,8 +198,7 @@ public class AppDetailsFragment extends BasePresenterFragment<AppDetailsContract
                     startActivity(new Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", c.getTarget(), null)));
                 } catch (Exception e) {
                     Timber.e(e, "Problem launching intent for Email contact");
-                    Toast.makeText(getContext(), getContext().getResources().getString(R.string.no_email_client), Toast.LENGTH_LONG).show();
-                    //note: translations pulled straight from google translate, someone might want to double check
+                    displayToast(R.string.no_email_client);
                 }
 
                 break;
@@ -273,6 +277,10 @@ public class AppDetailsFragment extends BasePresenterFragment<AppDetailsContract
         builder.setSecondaryToolbarColor(ContextCompat.getColor(getActivity(), R.color.colorPrimary));
         CustomTabsIntent customTabsIntent = builder.build();
         customTabsIntent.launchUrl(getActivity(), Uri.parse(url));
+    }
+
+    private void displayToast(int message) {
+        Toast.makeText(getContext(), message, Toast.LENGTH_SHORT).show();
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,4 +56,5 @@
         <item>1</item>
         <item>2</item>
     </string-array>
+    <string name="no_download_client">No client available for this download</string>
 </resources>


### PR DESCRIPTION
- Display toast instead of crashing if the app fails to handle a download properly (ie no Google Play installed)
- Fix instances where whitespaces are being included in downloadUrls