### PR TITLE
Markdown in Descriptions

### DIFF
--- a/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/BaseParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/BaseParser.java
@@ -10,4 +10,12 @@ public abstract class BaseParser implements AppParser {
     String fixEncoding(String input) {
         return encodingFixer.fixHtmlEscapes(input);
     }
+
+    String fixMarkdown(String input) {
+        return encodingFixer.convertStringToHtml(input);
+    }
+
+    String convertSubredditsToLinks(String input) {
+        return encodingFixer.convertSubredditsToLinks(input);
+    }
 }

--- a/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/BaseParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/BaseParser.java
@@ -12,7 +12,7 @@ public abstract class BaseParser implements AppParser {
     }
 
     String fixMarkdown(String input) {
-        return encodingFixer.convertStringToHtml(input);
+        return encodingFixer.convertMarkdownToHtml(input);
     }
 
     String convertSubredditsToLinks(String input) {

--- a/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/DescriptionColumnParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/DescriptionColumnParser.java
@@ -15,6 +15,10 @@ public class DescriptionColumnParser extends BaseParser {
         final String rawDescriptionString = rawColumns.get(Column.DESCRIPTION);
         // TODO we need to deal with markdown in the descriptions
         //noinspection deprecation
-        appInfo.setDescription(fixEncoding(rawDescriptionString));
+        String fixedDescription = fixEncoding(rawDescriptionString);
+        fixedDescription = fixMarkdown(fixedDescription);
+        fixedDescription = convertSubredditsToLinks(fixedDescription);
+
+        appInfo.setDescription(fixedDescription);
     }
 }

--- a/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/DescriptionColumnParser.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/DescriptionColumnParser.java
@@ -13,8 +13,7 @@ public class DescriptionColumnParser extends BaseParser {
     @Override
     public void parse(AppInfo appInfo, Map<Column, String> rawColumns) {
         final String rawDescriptionString = rawColumns.get(Column.DESCRIPTION);
-        // TODO we need to deal with markdown in the descriptions
-        //noinspection deprecation
+
         String fixedDescription = fixEncoding(rawDescriptionString);
         fixedDescription = fixMarkdown(fixedDescription);
         fixedDescription = convertSubredditsToLinks(fixedDescription);

--- a/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/EncodingFixer.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/EncodingFixer.java
@@ -15,46 +15,52 @@ public class EncodingFixer {
         return Html.fromHtml(input).toString();
     }
 
-    public String convertStringToHtml(String string) {
-        // Converts link markdown to HTML
-        String output = string;
-        Matcher urlMarkdownMatcher = URL_MARKDOWN_PATTERN.matcher(output);
-        while (urlMarkdownMatcher.find()) {
-            String matchedString = urlMarkdownMatcher.group(2);
-            String matchedUrl = urlMarkdownMatcher.group(3);
+    public String convertMarkdownToHtml(String input) {
+        input = urlMarkdownToHtml(input);
+        input = boldMarkdownToHtml(input);
 
-            String fixedString = "<a href=\"" + matchedUrl + "\">" + matchedString + "</a>";
-
-            output = output.replace(urlMarkdownMatcher.group(1), fixedString);
-        }
-
-        // Converts bold markdown to HTML
-        Matcher boldMarkdownMatcher = BOLD_MARKDOWN_PATTERN.matcher(output);
-        while (boldMarkdownMatcher.find()) {
-            String matchedString = boldMarkdownMatcher.group(2);
-
-            String fixedString = "<b>" + matchedString + "</b>";
-
-            output = output.replace(boldMarkdownMatcher.group(1), fixedString);
-        }
-
-        return output;
+        return input;
     }
 
-    public String convertSubredditsToLinks(String string) {
+    public String convertSubredditsToLinks(String input) {
         // Converts subreddit mentions to links in HTML
-        String output = string;
-        Matcher subredditMatcher = SUBREDDIT_PATTERN.matcher(output);
+        Matcher subredditMatcher = SUBREDDIT_PATTERN.matcher(input);
         while (subredditMatcher.find()) {
             String matchedSubreddit = subredditMatcher.group(1);
 
             String fixedString = "<a href=\"https://www.reddit.com" + matchedSubreddit +
                     "\">" + matchedSubreddit + "</a>";
 
-            output = output.replaceAll(matchedSubreddit + "(?!\\S)", fixedString);
+            input = input.replaceAll(matchedSubreddit + "(?!\\S)", fixedString);
         }
+        return input;
+    }
 
-        return output;
+    // Converts string with link markdown to HTML
+    private String urlMarkdownToHtml(String string) {
+        Matcher urlMarkdownMatcher = URL_MARKDOWN_PATTERN.matcher(string);
+        while (urlMarkdownMatcher.find()) {
+            String matchedString = urlMarkdownMatcher.group(2);
+            String matchedUrl = urlMarkdownMatcher.group(3);
+
+            String fixedString = "<a href=\"" + matchedUrl + "\">" + matchedString + "</a>";
+
+            string = string.replace(urlMarkdownMatcher.group(1), fixedString);
+        }
+        return string;
+    }
+
+    // Converts string with bold markdown to HTML
+    private String boldMarkdownToHtml(String string) {
+        Matcher boldMarkdownMatcher = BOLD_MARKDOWN_PATTERN.matcher(string);
+        while (boldMarkdownMatcher.find()) {
+            String matchedString = boldMarkdownMatcher.group(2);
+
+            String fixedString = "<b>" + matchedString + "</b>";
+
+            string = string.replace(boldMarkdownMatcher.group(1), fixedString);
+        }
+        return string;
     }
 
 }

--- a/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/EncodingFixer.java
+++ b/app/src/main/java/subreddit/android/appstore/backend/reddit/wiki/parser/EncodingFixer.java
@@ -2,11 +2,59 @@ package subreddit.android.appstore.backend.reddit.wiki.parser;
 
 import android.text.Html;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class EncodingFixer {
+    private static final Pattern URL_MARKDOWN_PATTERN = Pattern.compile("(\\[(.*?)\\]\\s{0,1}\\((http.*?)\\))");
+    private static final Pattern BOLD_MARKDOWN_PATTERN = Pattern.compile("(\\*\\*(.*?)\\*\\*)");
+    private static final Pattern SUBREDDIT_PATTERN = Pattern.compile("(\\/r\\/.*?(?!\\S))");
 
     public String fixHtmlEscapes(String input) {
         //noinspection deprecation
         return Html.fromHtml(input).toString();
+    }
+
+    public String convertStringToHtml(String string) {
+        // Converts link markdown to HTML
+        String output = string;
+        Matcher urlMarkdownMatcher = URL_MARKDOWN_PATTERN.matcher(output);
+        while (urlMarkdownMatcher.find()) {
+            String matchedString = urlMarkdownMatcher.group(2);
+            String matchedUrl = urlMarkdownMatcher.group(3);
+
+            String fixedString = "<a href=\"" + matchedUrl + "\">" + matchedString + "</a>";
+
+            output = output.replace(urlMarkdownMatcher.group(1), fixedString);
+        }
+
+        // Converts bold markdown to HTML
+        Matcher boldMarkdownMatcher = BOLD_MARKDOWN_PATTERN.matcher(output);
+        while (boldMarkdownMatcher.find()) {
+            String matchedString = boldMarkdownMatcher.group(2);
+
+            String fixedString = "<b>" + matchedString + "</b>";
+
+            output = output.replace(boldMarkdownMatcher.group(1), fixedString);
+        }
+
+        return output;
+    }
+
+    public String convertSubredditsToLinks(String string) {
+        // Converts subreddit mentions to links in HTML
+        String output = string;
+        Matcher subredditMatcher = SUBREDDIT_PATTERN.matcher(output);
+        while (subredditMatcher.find()) {
+            String matchedSubreddit = subredditMatcher.group(1);
+
+            String fixedString = "<a href=\"https://www.reddit.com" + matchedSubreddit +
+                    "\">" + matchedSubreddit + "</a>";
+
+            output = output.replaceAll(matchedSubreddit + "(?!\\S)", fixedString);
+        }
+
+        return output;
     }
 
 }

--- a/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsFragment.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsFragment.java
@@ -4,6 +4,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -13,6 +14,8 @@ import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
+import android.text.Html;
+import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -224,7 +227,12 @@ public class AppDetailsFragment extends BasePresenterFragment<AppDetailsContract
         secondaryTitle.setText(appInfo.getSecondaryCategory());
         downloads = new ArrayList<>(appInfo.getDownloads());
         contacts = new ArrayList<>(appInfo.getContacts());
-        description.setText(appInfo.getDescription());
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+            description.setText(Html.fromHtml(appInfo.getDescription(), Html.FROM_HTML_MODE_COMPACT));
+        else description.setText(Html.fromHtml(appInfo.getDescription()));
+        description.setMovementMethod(LinkMovementMethod.getInstance());
+
         tagContainer.removeAllViews();
         for (AppTags appTags : appInfo.getTags()) {
             TextView tv = (TextView) LayoutInflater.from(getContext()).inflate(R.layout.view_tagtemplate, tagContainer, false);

--- a/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsFragment.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/details/AppDetailsFragment.java
@@ -228,9 +228,11 @@ public class AppDetailsFragment extends BasePresenterFragment<AppDetailsContract
         downloads = new ArrayList<>(appInfo.getDownloads());
         contacts = new ArrayList<>(appInfo.getContacts());
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             description.setText(Html.fromHtml(appInfo.getDescription(), Html.FROM_HTML_MODE_COMPACT));
-        else description.setText(Html.fromHtml(appInfo.getDescription()));
+        } else {
+            description.setText(Html.fromHtml(appInfo.getDescription()));
+        }
         description.setMovementMethod(LinkMovementMethod.getInstance());
 
         tagContainer.removeAllViews();

--- a/app/src/main/java/subreddit/android/appstore/screens/list/AppListAdapter.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/list/AppListAdapter.java
@@ -1,7 +1,9 @@
 package subreddit.android.appstore.screens.list;
 
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
+import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -91,7 +93,11 @@ public class AppListAdapter extends BaseAdapter<AppListAdapter.ViewHolder> imple
 
         public void bind(AppInfo item) {
             appName.setText(item.getAppName());
-            description.setText(item.getDescription());
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                description.setText(Html.fromHtml(item.getDescription(), Html.FROM_HTML_MODE_COMPACT));
+            else description.setText(Html.fromHtml(item.getDescription()));
+
             if (PreferenceManager.getDefaultSharedPreferences(getContext()).getBoolean(SettingsActivity.PREF_KEY_LOAD_MEDIA, true)) {
                 iconFrame.setVisibility(View.VISIBLE);
                 GlideApp.with(getContext())

--- a/app/src/main/java/subreddit/android/appstore/screens/list/AppListAdapter.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/list/AppListAdapter.java
@@ -94,9 +94,11 @@ public class AppListAdapter extends BaseAdapter<AppListAdapter.ViewHolder> imple
         public void bind(AppInfo item) {
             appName.setText(item.getAppName());
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 description.setText(Html.fromHtml(item.getDescription(), Html.FROM_HTML_MODE_COMPACT));
-            else description.setText(Html.fromHtml(item.getDescription()));
+            } else {
+                description.setText(Html.fromHtml(item.getDescription()));
+            }
 
             if (PreferenceManager.getDefaultSharedPreferences(getContext()).getBoolean(SettingsActivity.PREF_KEY_LOAD_MEDIA, true)) {
                 iconFrame.setVisibility(View.VISIBLE);

--- a/app/src/mock/java/subreddit/android/appstore/backend/reddit/wiki/FakeWikiRepository.java
+++ b/app/src/mock/java/subreddit/android/appstore/backend/reddit/wiki/FakeWikiRepository.java
@@ -53,7 +53,7 @@ public class FakeWikiRepository implements WikiRepository {
             AppInfo app3 = new AppInfo();
             app3.setAppName("Markdown Test");
             app3.setDescription(
-                    encodingFixer.convertStringToHtml("Tutorial **screencast** for [Propellerheads Reason](https://www.propellerheads.se/products/reason/)")
+                    encodingFixer.convertMarkdownToHtml("Tutorial **screencast** for [Propellerheads Reason](https://www.propellerheads.se/products/reason/)")
             );
             app3.setCategories(new ArrayList<String>(Arrays.asList("Testing", "Examples", "Descriptions")));
             app3.addTag(AppTags.WEAR);

--- a/app/src/mock/java/subreddit/android/appstore/backend/reddit/wiki/FakeWikiRepository.java
+++ b/app/src/mock/java/subreddit/android/appstore/backend/reddit/wiki/FakeWikiRepository.java
@@ -10,6 +10,7 @@ import io.reactivex.Observable;
 import io.reactivex.subjects.ReplaySubject;
 import subreddit.android.appstore.backend.data.AppInfo;
 import subreddit.android.appstore.backend.data.AppTags;
+import subreddit.android.appstore.backend.reddit.wiki.parser.EncodingFixer;
 
 
 public class FakeWikiRepository implements WikiRepository {
@@ -28,6 +29,7 @@ public class FakeWikiRepository implements WikiRepository {
     }
 
     private Observable<Collection<AppInfo>> loadData() {
+        EncodingFixer encodingFixer = new EncodingFixer();
         return Observable.defer(() -> {
             Collection<AppInfo> testValues = new ArrayList<>();
             AppInfo app1 = new AppInfo();
@@ -46,6 +48,29 @@ public class FakeWikiRepository implements WikiRepository {
             app2.addTag(AppTags.PAID);
             app2.addTag(AppTags.NEW);
             testValues.add(app2);
+
+            // Test app with bold and link markdown in description
+            AppInfo app3 = new AppInfo();
+            app3.setAppName("Markdown Test");
+            app3.setDescription(
+                    encodingFixer.convertStringToHtml("Tutorial **screencast** for [Propellerheads Reason](https://www.propellerheads.se/products/reason/)"));
+            app3.setCategories(new ArrayList<String>(Arrays.asList("Testing", "Examples", "Descriptions")));
+            app3.addTag(AppTags.WEAR);
+            app3.addTag(AppTags.PAID);
+            app3.addTag(AppTags.NEW);
+            testValues.add(app3);
+
+            // Test app with Subreddit link conversion
+            AppInfo app4 = new AppInfo();
+            app4.setAppName("Subreddit Link Conversion Test");
+            app4.setDescription(
+                    encodingFixer.convertSubredditsToLinks("Wow! /r/Android is the bestest ever."));
+            app4.setCategories(new ArrayList<String>(Arrays.asList("Testing", "Examples", "Descriptions")));
+            app4.addTag(AppTags.WEAR);
+            app4.addTag(AppTags.PAID);
+            app4.addTag(AppTags.NEW);
+            testValues.add(app4);
+
             for (int i = 0; i < 1000; i++) {
                 AppInfo randomApp = new AppInfo();
                 randomApp.setAppName(UUID.randomUUID().toString() + " app");

--- a/app/src/mock/java/subreddit/android/appstore/backend/reddit/wiki/FakeWikiRepository.java
+++ b/app/src/mock/java/subreddit/android/appstore/backend/reddit/wiki/FakeWikiRepository.java
@@ -53,7 +53,8 @@ public class FakeWikiRepository implements WikiRepository {
             AppInfo app3 = new AppInfo();
             app3.setAppName("Markdown Test");
             app3.setDescription(
-                    encodingFixer.convertStringToHtml("Tutorial **screencast** for [Propellerheads Reason](https://www.propellerheads.se/products/reason/)"));
+                    encodingFixer.convertStringToHtml("Tutorial **screencast** for [Propellerheads Reason](https://www.propellerheads.se/products/reason/)")
+            );
             app3.setCategories(new ArrayList<String>(Arrays.asList("Testing", "Examples", "Descriptions")));
             app3.addTag(AppTags.WEAR);
             app3.addTag(AppTags.PAID);
@@ -64,7 +65,8 @@ public class FakeWikiRepository implements WikiRepository {
             AppInfo app4 = new AppInfo();
             app4.setAppName("Subreddit Link Conversion Test");
             app4.setDescription(
-                    encodingFixer.convertSubredditsToLinks("Wow! /r/Android is the bestest ever."));
+                    encodingFixer.convertSubredditsToLinks("Wow! /r/Android is the bestest ever.")
+            );
             app4.setCategories(new ArrayList<String>(Arrays.asList("Testing", "Examples", "Descriptions")));
             app4.addTag(AppTags.WEAR);
             app4.addTag(AppTags.PAID);

--- a/app/src/test/java/subreddit/android/appstore/backend/reddit/wiki/parser/DescriptionColumnParserTest.java
+++ b/app/src/test/java/subreddit/android/appstore/backend/reddit/wiki/parser/DescriptionColumnParserTest.java
@@ -31,8 +31,19 @@ public class DescriptionColumnParserTest {
                 return invocation.getArgument(0);
             }
         });
+        when(encodingFixer.convertStringToHtml(anyString())).then(new Answer<String>() {
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return invocation.getArgument(0);
+            }
+        });
+        when(encodingFixer.convertSubredditsToLinks(anyString())).then(new Answer<String>() {
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return invocation.getArgument(0);
+            }
+        });
         parser = new DescriptionColumnParser(encodingFixer);
     }
+
     @Test
     public void testParse() throws IOException {
         String rawDescriptionData = "This is a description";
@@ -43,16 +54,5 @@ public class DescriptionColumnParserTest {
 
         assertFalse(appInfo.getDescription().isEmpty());
         assertEquals("This is a description", appInfo.getDescription());
-    }
-
-    @Test
-    public void testParse_withMarkdown() throws IOException {
-        String rawDescriptionData = "";
-        Map<AppParser.Column, String> rawColumnMap = new HashMap<>();
-        rawColumnMap.put(AppParser.Column.DESCRIPTION, rawDescriptionData);
-        AppInfo appInfo = new AppInfo();
-        parser.parse(appInfo, rawColumnMap);
-
-        //TODO: Implement markdown parsing in DescriptionColumnParser as well
     }
 }

--- a/app/src/test/java/subreddit/android/appstore/backend/reddit/wiki/parser/DescriptionColumnParserTest.java
+++ b/app/src/test/java/subreddit/android/appstore/backend/reddit/wiki/parser/DescriptionColumnParserTest.java
@@ -31,7 +31,7 @@ public class DescriptionColumnParserTest {
                 return invocation.getArgument(0);
             }
         });
-        when(encodingFixer.convertStringToHtml(anyString())).then(new Answer<String>() {
+        when(encodingFixer.convertMarkdownToHtml(anyString())).then(new Answer<String>() {
             public String answer(InvocationOnMock invocation) throws Throwable {
                 return invocation.getArgument(0);
             }

--- a/app/src/test/java/subreddit/android/appstore/backend/reddit/wiki/parser/EncodingFixerTest.java
+++ b/app/src/test/java/subreddit/android/appstore/backend/reddit/wiki/parser/EncodingFixerTest.java
@@ -1,0 +1,58 @@
+package subreddit.android.appstore.backend.reddit.wiki.parser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class EncodingFixerTest {
+    private String descriptionBoldMarkdown, descriptionLinkMarkdown, descriptionSubreddits;
+    private EncodingFixer encodingFixer;
+
+    @Before
+    public void setup() {
+        encodingFixer = new EncodingFixer();
+
+        descriptionBoldMarkdown = "New ingenious full feature Reddit client. **Read AMA in magazine" +
+                "style QA format.** Add upcoming AMA to your calendar. **Only app with Text to " +
+                "Speech: Listen to the content.** Zero wait, streams all GIF instantly.";
+        descriptionLinkMarkdown = "Tutorial screencast for [Propellerheads Reason](https://www" +
+                ".propellerheads.se/products/reason/) and [Link 2](https://www.google.com)";
+        descriptionSubreddits = "You can setup playlists, geofences, volume control, and share" +
+                " playlists with others. Share playlists at /r/androidrrm and /r/android";
+    }
+
+    @Test
+    public void testConvertStringToHtml() {
+        String output = encodingFixer.convertStringToHtml("");
+        assertEquals("", output);
+
+        output = encodingFixer.convertStringToHtml("This description has no markdown");
+        assertEquals("This description has no markdown", output);
+    }
+
+    @Test
+    public void testConvertStringToHtml_bold() {
+        String output = encodingFixer.convertStringToHtml(descriptionBoldMarkdown);
+        assertEquals("New ingenious full feature Reddit client. <b>Read AMA in magazine" +
+                "style QA format.</b> Add upcoming AMA to your calendar. <b>Only app with Text to " +
+                "Speech: Listen to the content.</b> Zero wait, streams all GIF instantly.", output);
+    }
+
+    @Test
+    public void testConvertStringToHtml_link() {
+        String output = encodingFixer.convertStringToHtml(descriptionLinkMarkdown);
+        assertEquals("Tutorial screencast for " +
+                "<a href=\"https://www.propellerheads.se/products/reason/\">" +
+                "Propellerheads Reason</a> and <a href=\"https://www.google.com\">Link 2</a>", output);
+    }
+
+    @Test
+    public void testConvertSubredditsToLinks() {
+        String output = encodingFixer.convertSubredditsToLinks(descriptionSubreddits);
+        assertEquals("You can setup playlists, geofences, volume control, and share " +
+                "playlists with others. Share playlists at " +
+                "<a href=\"https://www.reddit.com/r/androidrrm\">/r/androidrrm</a> " +
+                "and <a href=\"https://www.reddit.com/r/android\">/r/android</a>", output);
+    }
+}

--- a/app/src/test/java/subreddit/android/appstore/backend/reddit/wiki/parser/EncodingFixerTest.java
+++ b/app/src/test/java/subreddit/android/appstore/backend/reddit/wiki/parser/EncodingFixerTest.java
@@ -23,25 +23,25 @@ public class EncodingFixerTest {
     }
 
     @Test
-    public void testConvertStringToHtml() {
-        String output = encodingFixer.convertStringToHtml("");
+    public void testConvertMarkdownToHtml() {
+        String output = encodingFixer.convertMarkdownToHtml("");
         assertEquals("", output);
 
-        output = encodingFixer.convertStringToHtml("This description has no markdown");
+        output = encodingFixer.convertMarkdownToHtml("This description has no markdown");
         assertEquals("This description has no markdown", output);
     }
 
     @Test
-    public void testConvertStringToHtml_bold() {
-        String output = encodingFixer.convertStringToHtml(descriptionBoldMarkdown);
+    public void testConvertMarkdownToHtml_bold() {
+        String output = encodingFixer.convertMarkdownToHtml(descriptionBoldMarkdown);
         assertEquals("New ingenious full feature Reddit client. <b>Read AMA in magazine" +
                 "style QA format.</b> Add upcoming AMA to your calendar. <b>Only app with Text to " +
                 "Speech: Listen to the content.</b> Zero wait, streams all GIF instantly.", output);
     }
 
     @Test
-    public void testConvertStringToHtml_link() {
-        String output = encodingFixer.convertStringToHtml(descriptionLinkMarkdown);
+    public void testConvertMarkdownToHtml_link() {
+        String output = encodingFixer.convertMarkdownToHtml(descriptionLinkMarkdown);
         assertEquals("Tutorial screencast for " +
                 "<a href=\"https://www.propellerheads.se/products/reason/\">" +
                 "Propellerheads Reason</a> and <a href=\"https://www.google.com\">Link 2</a>", output);


### PR DESCRIPTION
**For:**
#8 - Deal with markdown in descriptions

**Changes:**
- Convert bold and link markdown to HTML equivalents (handled by `EncodingFixer`)
- Subreddit mentions ("/r/Android") are converted to HTML links
- Support for HTML app descriptions in App Details view and App List view
- Links are clickable in App Details view
- Unit tests and Mockito additions for changes

![image](https://user-images.githubusercontent.com/23356519/29493023-fb95e1f0-8541-11e7-9296-6a370eb4f952.png)
![image](https://user-images.githubusercontent.com/23356519/29493024-fe5039b8-8541-11e7-9ff0-afe0bdd4285f.png)