### PR TITLE
Fixes #142: Fix new AppDetails layout

### DIFF
--- a/app/src/main/res/layout/fragment_appdetails_layout.xml
+++ b/app/src/main/res/layout/fragment_appdetails_layout.xml
@@ -17,10 +17,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fitsSystemWindows="true"
+            android:theme="@style/AppTheme.Dark"
             app:layout_scrollFlags="scroll|exitUntilCollapsed|snap"
             app:expandedTitleMarginStart="8dp"
             app:expandedTitleMarginEnd="8dp"
-            app:expandedTitleMarginBottom="124dp"
+            app:expandedTitleMarginBottom="84dp"
             app:expandedTitleGravity="center_horizontal|bottom"
             app:expandedTitleTextAppearance="@style/TextAppearance.AppCompat.Title">
 
@@ -37,6 +38,7 @@
                 android:layout_height="match_parent"
                 android:layout_width="match_parent"
                 android:orientation="vertical"
+                android:layout_marginTop="?attr/actionBarSize"
                 app:layout_collapseMode="parallax"
                 app:layout_collapseParallaxMultiplier="0.7">
 
@@ -85,7 +87,8 @@
                     android:paddingLeft="16dp"
                     android:paddingRight="16dp"
                     android:paddingStart="16dp"
-                    android:paddingTop="8dp"/>
+                    android:paddingTop="8dp"
+                    android:paddingBottom="32dp"/>
             </LinearLayout>
 
         </android.support.design.widget.CollapsingToolbarLayout>
@@ -94,6 +97,8 @@
     <android.support.v4.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:paddingBottom="50dp"
+        android:clipToPadding="false"
         app:behavior_overlapTop="30dp"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 


### PR DESCRIPTION
**For:**
Issue #142: After the redesigned AppDetails page from #131, relaunching Android Studio and rebuilding the app caused all sorts of weird things to happen

**Changes:**
- Better specification of margins, themes, etc. in layout file
- Added bottom padding underneath the Description CardView to prevent Download FAB from obstructing description when in landscape or when description is very long, example:
![appdetailspatch](https://user-images.githubusercontent.com/23356519/29994352-c5b2a276-8f82-11e7-8305-0261bf2208cb.png)
