### PR TITLE
Fixes #109: Check signature for hardcoded match to GitHub build signature

### DIFF
--- a/app/src/main/java/subreddit/android/appstore/AppStoreApp.java
+++ b/app/src/main/java/subreddit/android/appstore/AppStoreApp.java
@@ -1,12 +1,23 @@
 package subreddit.android.appstore;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.content.pm.Signature;
 import android.preference.PreferenceManager;
 
 import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
@@ -15,6 +26,7 @@ import timber.log.Timber;
 
 public class AppStoreApp extends Application {
     public static final String LOGPREFIX = "RAS:";
+    public static final String GITHUB_SIGNATURE = "FC4E2523E3509BA56E6AFDC36004958E2E94EAB2";
     private static RefWatcher refWatcher;
     private int theme = 0;
 
@@ -94,5 +106,29 @@ public class AppStoreApp extends Application {
         public AppComponent getAppComponent() {
             return appComponent;
         }
+    }
+
+    public static List<String> getSignatures(Context context, String packageName) {
+        List<String> foundSignatures = new ArrayList<>();
+        try {
+            final Signature[] signatures = context.getPackageManager().getPackageInfo(packageName, PackageManager.GET_SIGNATURES).signatures;
+            for (final Signature sig : signatures) {
+                final byte[] rawCert = sig.toByteArray();
+                InputStream certStream = new ByteArrayInputStream(rawCert);
+                CertificateFactory certFactory = CertificateFactory.getInstance("X509");
+                X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(certStream);
+
+                MessageDigest md = MessageDigest.getInstance("SHA1");
+                byte[] publicKey = md.digest(x509Cert.getEncoded());
+                foundSignatures.add(bytesToHex(publicKey).toUpperCase());
+            }
+        } catch (Exception e) { e.printStackTrace(); }
+        return foundSignatures;
+    }
+
+    private static String bytesToHex(byte[] in) {
+        final StringBuilder out = new StringBuilder();
+        for (byte b : in) out.append(String.format("%02x", b));
+        return out.toString();
     }
 }

--- a/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationFragment.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationFragment.java
@@ -139,7 +139,7 @@ public class NavigationFragment extends BasePresenterFragment<NavigationContract
         if (buildFromGithub()) {
             builder.setMessage(message + desc);
         } else {
-            builder.setMessage(message + desc + "\n" + R.string.build_from_fdroid);
+            builder.setMessage(message + R.string.build_from_fdroid + "\n" + desc);
         }
 
         builder.setPositiveButton(R.string.update_confirm, (dialog, id) -> getPresenter().downloadUpdate(release));

--- a/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationFragment.java
+++ b/app/src/main/java/subreddit/android/appstore/screens/navigation/NavigationFragment.java
@@ -21,6 +21,7 @@ import android.widget.Toast;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -130,10 +131,17 @@ public class NavigationFragment extends BasePresenterFragment<NavigationContract
         String desc = release.releaseDescription;
         String name = release.releaseName;
         String tag = release.tagName;
+        String message =
+                DateFormat.format("MMM", date) + " " + DateFormat.format("dd", date) + "\n";
 
-        builder.setMessage(DateFormat.format("MMM", date) + " "
-                    + DateFormat.format("dd", date) + "\n" + desc)
-                .setTitle(tag + ": " + name);
+        builder.setTitle(tag + ": " + name);
+
+        if (buildFromGithub()) {
+            builder.setMessage(message + desc);
+        } else {
+            builder.setMessage(message + desc + "\n" + R.string.build_from_fdroid);
+        }
+
         builder.setPositiveButton(R.string.update_confirm, (dialog, id) -> getPresenter().downloadUpdate(release));
         builder.setNegativeButton(R.string.cancel, (dialog, id) -> dialog.dismiss());
         AlertDialog dialog = builder.create();
@@ -226,6 +234,16 @@ public class NavigationFragment extends BasePresenterFragment<NavigationContract
 
     public interface OnCategorySelectedListener {
         void onCategorySelected(CategoryFilter filter);
+    }
+
+    private boolean buildFromGithub() {
+        List<String> signatures =
+                AppStoreApp.getSignatures(getContext(), "subreddit.android.appstore");
+
+        for (String signature : signatures) {
+            if (signature.equals(AppStoreApp.GITHUB_SIGNATURE)) return true;
+        }
+        return false;
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="no_message">Please enter a message</string>
     <string name="no_email_client">No email client available</string>
     <string name="flag_text">Please describe why you are flagging this app. You will be redirected to reddit to send a PM to the r/Android mod team</string>
+    <string name="build_from_fdroid">Note: If you downloaded this app from F-Droid, the download link will require a reinstall.</string>
     <plurals name="x_items">
         <item quantity="one">%s item</item>
         <item quantity="other">%s items</item>


### PR DESCRIPTION
**For:**
Issue #109: Notify F-Droid users that download link in Update dialogue won't work for them, relevant comment [here](https://github.com/d4rken/reddit-android-appstore/issues/104#issuecomment-317464573):

> This can be solved by comparing the signature of the apk that is installed (which can be accessed through the packagemanager) and comparing it with the signature of the github build apks (which doesn't change and could be hardcoded)

**Changes:**
When showing changelog, check for a signature match and add a line notifying users that using the download link will require a reinstall

Isn't the point of the signature that it should be hidden though? 😕 