### PR TITLE
Issue #108: Adding German translations

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -39,5 +39,18 @@
     <string name="website">Internetseite</string>
     <string name="app_category_new">Neu</string>
     <string name="no_email_client">Kein E-Mail-Client verfügbar</string>
-    <string name="submitapp">Submit an App</string>
+    <string name="submitapp">App einreichen</string>
+    <string name="view_update">Ansehen</string>
+    <string name="update_error">Fehler beim Suchen nach Updates</string>
+    <string name="cancel">Abbrechen</string>
+    <string-array name="themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>AMOLED</item>
+    </string-array>
+    <string-array name="themesValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
I have added the missing German translations mentioned in #108 and also translated the `submitapp` string.

Some Remarks / Questions:

- I could also translate the themes strings ("Light", "Dark") if you want, but I personally think that would sound very forced/unnatural. Many German Apps/Programs just use "Light" and "Dark" and don't translate it.
- I also copied the "themesValues" array from the values.xml because it appeared in the error log. Is that correct or should I remove it?