### PR TITLE
Upgraded Dagger from 2.9 to 2.11 to fix Glide/javapoet issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -213,8 +213,8 @@ dependencies {
     compile 'com.google.code.gson:gson:2.7'
 
     //Dagger
-    compile 'com.google.dagger:dagger:2.9'
-    annotationProcessor "com.google.dagger:dagger-compiler:2.9"
+    compile 'com.google.dagger:dagger:2.11'
+    annotationProcessor "com.google.dagger:dagger-compiler:2.11"
     provided 'javax.annotation:jsr250-api:1.0'
 
     //Butterknife


### PR DESCRIPTION
Upgraded Dagger from 2.9 to 2.11 to fix Glide/javapoet issue that was discussed in #155 